### PR TITLE
Pass environment to `rlang::as_function()`

### DIFF
--- a/R/qstats.r
+++ b/R/qstats.r
@@ -50,7 +50,7 @@ qstats <- function(data, x, ...,
   my_sum <- function(data, col, cus_sum) {
     col <- enquo(col)
     cus_sum_name <- cus_sum
-    cus_sum <- rlang::as_function(cus_sum)
+    cus_sum <- rlang::as_function(cus_sum, env = current_env())
 
     data %>%
       summarise(!!cus_sum_name := cus_sum(!!col))


### PR DESCRIPTION
This will be necessary in rlang 1.0.0 when a function name is passed instead of a function.

From the NEWS file:

> If a string is supplied to `as_function()` instead of an object (function or formula), the function is looked up in the global environment instead of the calling environment. In general, passing a function name as a string is brittle. It is easy to forget to pass the user environment to `as_function()` and sometimes there is no obvious user environment. The support for strings should be considered a convenience for end users only, not for programmers.
>
> Since environment forwarding is easy to mess up, and since the feature is aimed towards end users, `as_function()` now defaults to the global environment. Supply an environment explicitly if that is not correct in your case.

We plan to release rlang 1.0 this week. Sorry in advance for the breakage to come.